### PR TITLE
Adjusting package and distro versions to better match Pi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
-dist: xenial
+dist: jessie
 language: java
 jdk:
   # Install JDK8 for html5 validator.
   - oraclejdk8
 env:
-  - NODE_VERSION="6.9.5" PHANTOMJS_VERSION="2.1.1" PATH="$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
+  - NODE_VERSION="0.12" PHANTOMJS_VERSION="2.1.1" PATH="$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
 cache:
   directories:
     - travis_phantomjs

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "bower": "^1.6.5",
     "coveralls": "^2.11.6",
-    "html-validator-cli": "^3.1.0",
+    "html-validator-cli": "^2.0.0",
     "http-server": "^0.9.0",
     "jasmine-core": "^2.3.4",
     "jscs": "^3.0.7",


### PR DESCRIPTION
Raspbian is based on Debian Jessie. Also the Raspbian version of node is 0.12
so changing to that version and downgrading the html-validator package to
match.