### PR TITLE
Adding images directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ tmp
 
 npm-debug.log
 
+# Images are not under source control.
+app/images/
+
 # Ignore vim temp files.
 *.swp
 *.swo


### PR DESCRIPTION
After deployment, the static directory will have a symlink at the path
app/images into the system's folder for greenpithumb images, but images should
be ignored by source control.

See also: https://github.com/JeetShetty/ansible-role-greenpithumb/pull/28