### PR TITLE
Adding tests for controller

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var model = {};
-
 var greenPiThumbApp = angular.module('greenPiThumbApp', [
   'greenPiThumbApp.directives',
   'greenPiThumbApp.version'
@@ -10,29 +8,25 @@ var greenPiThumbApp = angular.module('greenPiThumbApp', [
 angular.module('d3', []);
 angular.module('greenPiThumbApp.directives', ['d3']);
 
-greenPiThumbApp.run(function($http) {
+greenPiThumbApp.controller('DashboardCtrl', function($scope, $http) {
   $http.get('/temperatureHistory.json').success(function(temperatureHistory) {
-    model.latestTemperature =
+    $scope.latestTemperature =
       temperatureHistory[temperatureHistory.length - 1].temperature;
-    model.temperature = temperatureHistory;
+    $scope.temperature = temperatureHistory;
   });
   $http.get('/humidityHistory.json').success(function(humidityHistory) {
-    model.humidity = humidityHistory;
-    model.latestHumidity =
+    $scope.humidity = humidityHistory;
+    $scope.latestHumidity =
       humidityHistory[humidityHistory.length - 1].humidity;
   });
   $http.get('/lightHistory.json').success(function(lightHistory) {
-    model.lightLevel = lightHistory;
-    model.latestLightLevel =
+    $scope.lightLevel = lightHistory;
+    $scope.latestLightLevel =
       lightHistory[lightHistory.length - 1].light;
   });
   $http.get('/soilMoistureHistory.json').success(function(moistureHistory) {
-    model.soilMoisture = moistureHistory;
-    model.latestSoilMoisture =
+    $scope.soilMoisture = moistureHistory;
+    $scope.latestSoilMoisture =
       moistureHistory[moistureHistory.length - 1].soil_moisture;
   });
-});
-
-greenPiThumbApp.controller('DashboardCtrl', function($scope) {
-  $scope.dashboard = model;
 });

--- a/app/app_test.js
+++ b/app/app_test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+describe('greenPiThumbApp controller', function() {
+  var mockScope = {};
+  var controller;
+  var backend;
+
+  beforeEach(angular.mock.module('greenPiThumbApp'));
+
+  beforeEach(angular.mock.inject(function($httpBackend) {
+    backend = $httpBackend;
+    backend.expect('GET', '/temperatureHistory.json').respond(
+      [
+        {'timestamp': '20170408T1315Z', 'temperature': 22.0},
+        {'timestamp': '20170408T1330Z', 'temperature': 24.0},
+        {'timestamp': '20170408T1345Z', 'temperature': 25.0}
+      ]);
+    backend.expect('GET', '/humidityHistory.json').respond(
+      [
+        {'timestamp': '20170408T1315Z', 'humidity': 51.0},
+        {'timestamp': '20170408T1330Z', 'humidity': 52.0},
+        {'timestamp': '20170408T1345Z', 'humidity': 53.0}
+      ]);
+    backend.expect('GET', '/lightHistory.json').respond(
+      [
+        {'timestamp': '20170408T1315Z', 'light': 66.1},
+        {'timestamp': '20170408T1330Z', 'light': 66.2},
+        {'timestamp': '20170408T1345Z', 'light': 66.3}
+      ]);
+    backend.expect('GET', '/soilMoistureHistory.json').respond(
+      [
+        {'timestamp': '20170408T1315Z', 'soil_moisture': 888.0},
+        {'timestamp': '20170408T1330Z', 'soil_moisture': 888.1},
+        {'timestamp': '20170408T1345Z', 'soil_moisture': 888.2}
+      ]);
+  }));
+
+  beforeEach(angular.mock.inject(function($controller, $rootScope, $http) {
+    mockScope = $rootScope.$new();
+    controller = $controller('DashboardCtrl', {
+      $scope: mockScope,
+      $http: $http
+    });
+    backend.flush();
+  }));
+
+  it('makes all expected AJAX requestse', function() {
+    backend.verifyNoOutstandingExpectation();
+  });
+
+  it('Creates latest* variables', function() {
+    expect(mockScope.latestTemperature).toEqual(25.0);
+    expect(mockScope.latestHumidity).toEqual(53.0);
+    expect(mockScope.latestLightLevel).toEqual(66.3);
+    expect(mockScope.latestSoilMoisture).toEqual(888.2);
+  });
+
+  it('Creates full history variables', function() {
+    expect(mockScope.temperature).toBeDefined();
+    expect(mockScope.humidity).toBeDefined();
+    expect(mockScope.lightLevel).toBeDefined();
+    expect(mockScope.soilMoisture).toBeDefined();
+  });
+});

--- a/app/app_test.js
+++ b/app/app_test.js
@@ -44,7 +44,7 @@ describe('greenPiThumbApp controller', function() {
     backend.flush();
   }));
 
-  it('makes all expected AJAX requestse', function() {
+  it('makes all expected AJAX requests', function() {
     backend.verifyNoOutstandingExpectation();
   });
 

--- a/app/index.html
+++ b/app/index.html
@@ -17,29 +17,29 @@
   <table class="table table-hover">
     <tr>
       <td>Ambient Temperature</td>
-      <td>{{dashboard.latestTemperature | number:1}}&deg; C</td>
+      <td>{{ latestTemperature | number:1 }}&deg; C</td>
     </tr>
     <tr>
       <td>Ambient Humidity</td>
-      <td>{{dashboard.latestHumidity | number:0}}</td>
+      <td>{{ latestHumidity | number:0 }}</td>
     </tr>
     <tr>
       <td>Ambient Light</td>
-      <td>{{dashboard.latestLightLevel | number:1}}%</td>
+      <td>{{ latestLightLevel | number:1 }}%</td>
     </tr>
     <tr>
       <td>Soil Moisture</td>
-      <td>{{dashboard.latestSoilMoisture | number:0}}</td>
+      <td>{{ latestSoilMoisture | number:0 }}</td>
     </tr>
   </table>
   <h2>Temperature</h2>
-  <line-graph chart-data="dashboard.temperature" value-property="temperature"></line-graph>
+  <line-graph chart-data="temperature" value-property="temperature"></line-graph>
   <h2>Ambient Humidity</h2>
-  <line-graph chart-data="dashboard.humidity" value-property="humidity"></line-graph>
+  <line-graph chart-data="humidity" value-property="humidity"></line-graph>
   <h2>Ambient Light</h2>
-  <line-graph chart-data="dashboard.lightLevel" value-property="light"></line-graph>
+  <line-graph chart-data="lightLevel" value-property="light"></line-graph>
   <h2>Soil Moisture</h2>
-  <line-graph chart-data="dashboard.soilMoisture" value-property="soil_moisture"></line-graph>
+  <line-graph chart-data="soilMoisture" value-property="soil_moisture"></line-graph>
   <small class="clearfix">{{ 'GreenPiThumb Frontend version %VERSION%' | interpolate }}</small>
   <script src="bower_components/angular/angular.js"></script>
   <script src="app.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ module.exports = function(config) {
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'bower_components/d3/d3.js',
-      'app.js',
+      '*.js',
       'components/**/*.js',
       'services/**/*.js',
       'directives/**/*.js'


### PR DESCRIPTION
Refactors the code to move the model population into the controller.
Adds unit test coverage for the model population logic.

Note: The guides I've found for AngularJS testing say to arrange the tests this
way even though it feels to me like the tests cases are overly broad and share
a lot of state. Implementing it this way to start, then maybe will make them
more granular if we find a better way of testing in Angular.