### PR TITLE
Changing camera image width to use more screen real estate

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -52,6 +52,6 @@ div.tooltip {
 }
 
 div.cameraImage {
-  width: 65%;
-  margin-left: 15px;
+  max-width: 800px;
+  margin: 15px 5px;
 }


### PR DESCRIPTION
Now it maxes to 800px and scales down as the page gets smaller

This fixes #25